### PR TITLE
Removed hardcoded column span

### DIFF
--- a/src/scss/layout/_grid.scss
+++ b/src/scss/layout/_grid.scss
@@ -28,7 +28,7 @@
 
 @for $i from 1 through $grid-max-columns {
     .col-#{$i} {
-        @include span-columns(12);
+        @include span-columns($grid-max-columns);
 
         @include media($medium) {
             @include span-columns($i);


### PR DESCRIPTION
Replaced with `$grid-max-columns`, otherwise any project with a different column count will be wonky