### PR TITLE
Added postcss with autoprefixer

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,6 +232,24 @@ module.exports = function (grunt) {
                 }
             }
         },
+        
+        postcss: {
+            options: {
+                remove: false,
+                map: true,
+                processors: [
+                    require('autoprefixer-core')({
+                        browsers: ['> 1%', 'last 2 versions']
+                    })
+                ]
+            },
+            dev: {
+                src: [ '<%= paths.src.css %>/styles.css' ]
+            }
+            dist: {
+                src: [ '<%= paths.dist.css %>/styles.css' ]
+            }
+        },
 
         watch: {
             options: {
@@ -239,7 +257,7 @@ module.exports = function (grunt) {
             },
             sass: {
                 files: ['<%= paths.src.scss %>/{,*/}*.scss'],
-                tasks: ['sass:dev']
+                tasks: ['sass:dev', 'postcss:dev']
             },
             js: {
                 files: ['<%= paths.src.js %>/{,*/}*.js'],
@@ -252,6 +270,7 @@ module.exports = function (grunt) {
         'clean:dist',
         'copy',
         'sass:dist',
+        'postcss:dist',
         'jshint',
         'requirejs:dist',
         'processhtml',

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "Cameron Wardzala <cwardzala@findaway.com>",
   "license": "MIT",
   "devDependencies": {
+    "autoprefixer-core": "^5.2.0",
     "grunt": "^0.4.4",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-copy": "^0.5.0",
@@ -18,6 +19,7 @@
     "grunt-contrib-requirejs": "^0.4.3",
     "grunt-contrib-sass": "^0.9.2",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-postcss": "^0.5.1",
     "grunt-hashres": "^0.4.1",
     "grunt-processhtml": "^0.3.6",
     "grunt-string-replace": "^0.2.7",


### PR DESCRIPTION
Autoprefixes CSS after Sass is compiled during watch and build. Keeps Sass source clean and free of prefixes!